### PR TITLE
update to new s3 bucket on cci

### DIFF
--- a/climetlab_maelstrom_ens10/ens10.py
+++ b/climetlab_maelstrom_ens10/ens10.py
@@ -13,11 +13,12 @@ import climetlab as cml
 from climetlab import Dataset
 from climetlab.normalize import normalize_args
 
-__version__ = "0.1.1"
+__version__ = "0.2.1"
 
-URL = "https://storage.ecmwf.europeanweather.cloud"
 
-PATTERN = "{url}/MAELSTROM_AP4/output.{dtype}.2018{month}{day}"
+URL = "https://object-store.os-api.cci1.ecmwf.int"
+
+PATTERN = "{url}/maelstrom-ap4/output.{dtype}.2018{month}{day}"
 
 
 class Ens10(Dataset):

--- a/climetlab_maelstrom_ens10/toy.py
+++ b/climetlab_maelstrom_ens10/toy.py
@@ -13,11 +13,12 @@ import climetlab as cml
 from climetlab import Dataset
 from climetlab.normalize import normalize_args
 
-__version__ = "0.1.1"
+__version__ = "0.2.1"
 
-URL = "https://storage.ecmwf.europeanweather.cloud"
 
-PATTERN = "{url}/MAELSTROM_AP4/toy/ens5mini.{month}.nc"
+URL = "https://object-store.os-api.cci1.ecmwf.int"
+
+PATTERN = "{url}/maelstrom-ap4/toy/ens5mini.{month}.nc"
 
 
 class Ens5mini(Dataset):


### PR DESCRIPTION
Hello, this is Ana! I just joined ECMWF and I will be working on the MAELSTROM project, supporting the work already done specially for application 4 by @mchantry.  

I am opening this PR so that when loading the different datasets, we can use the new s3 cci bucket. Main changes introduced are the update URL to point to new https address and update the pattern since now all directories are with lower case and underscores have been replaced with dashes. This change is also inline with the update of [instructions](https://github.com/ecmwf/climetlab/blob/0d77312939f4d9ef5f450dc9ebb77b029671a438/HOWTO.md) done in climetlab by @floriankrb! 